### PR TITLE
[Bug] 키보드 나타났을 때, 검색 테이블 뷰 아래쪽 가려짐

### DIFF
--- a/WeatherApp/WeatherApp/Presentation/Search/View/Cell/SearchViewCell.swift
+++ b/WeatherApp/WeatherApp/Presentation/Search/View/Cell/SearchViewCell.swift
@@ -13,6 +13,7 @@ class SearchViewCell: UITableViewCell {
     private let label: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 17, weight: .medium)
+        label.textColor = .secondaryLabel
         return label
     }()
     


### PR DESCRIPTION
## 🔧 관련 이슈
closed #11 

## ✨ 변경 사항 및 이유
- 테이블 뷰 셀 아래쪽 가려지지 않게 변경
- 테이블 뷰 셀 폰트 컬러 변경
- 검색 뷰 컨트롤러에 onDismiss 클로저 추가(임시)

## 🔍 PR Point
- 없음

## 📌 참고 사항
검색 결과(위치 정보)를 메인 뷰 컨트롤러로 보내는 방법 검토
1안) 클로저 방식: 현재 임시로 코드 작성해 놨습니다.
2안) RxSwift 방식: 튜터님 문의 결과, 아래 처럼 하면 될거 같습니다.
메인 뷰 컨트롤러에서 최초 검색 뷰 컨트롤러 인스턴스 생성 시 검색 뷰 모델에 Observable을 주입 -> 검색 결과를 그 변수에 넣어서 방출 -> 메인 뷰 컨트롤러에서 그것을 구독하여 처리

![Simulator Screenshot - iPhone 16 Pro - 2025-05-21 at 17 51 27](https://github.com/user-attachments/assets/5c787bc0-a650-49a7-89b4-900916fe83f2)
