### PR TITLE
Feat/daily section

### DIFF
--- a/WeatherApp/WeatherApp/Presentation/Main/View/Cell/DailyWeatherCell.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/Cell/DailyWeatherCell.swift
@@ -48,7 +48,7 @@ final class DailyWeatherCell: UICollectionViewCell {
         return label
     }()
     
-    private let dailyTemperatureRange = DailyTemperatureRange()
+    let dailyTemperatureRange = DailyTemperatureRange()
     
     private let dailyTemperatureRangeStackView: UIStackView = {
         let sv = UIStackView()
@@ -99,6 +99,11 @@ final class DailyWeatherCell: UICollectionViewCell {
         
         iconAndPopStackView.snp.makeConstraints {
             $0.leading.equalTo(weekdayLabel.snp.trailing).offset(48)
+        }
+        
+        dailyTemperatureRange.snp.makeConstraints {
+            $0.width.equalTo(128)
+            $0.height.equalTo(16)
         }
         
         dailyTemperatureRangeStackView.snp.makeConstraints {

--- a/WeatherApp/WeatherApp/Presentation/Main/View/Cell/DailyWeatherCell.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/Cell/DailyWeatherCell.swift
@@ -6,7 +6,121 @@
 //
 
 import UIKit
+import SnapKit
 
-class DailyWeatherCell: UICollectionViewCell {
+final class DailyWeatherCell: UICollectionViewCell {
+    static let id = "DailyWeatherCell"
     
+    private let weekdayLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13, weight: .medium)
+        return label
+    }()
+    
+    private let weatherIconImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFit
+        return iv
+    }()
+    
+    private let popLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 10, weight: .regular)
+        return label
+    }()
+    
+    private let iconAndPopStackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .vertical
+        sv.alignment = .center
+        return sv
+    }()
+    
+    private let highTempLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        return label
+    }()
+    
+    private let lowTempLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        return label
+    }()
+    
+    private let dailyTemperatureRange = DailyTemperatureRange()
+    
+    private let dailyTemperatureRangeStackView: UIStackView = {
+        let sv = UIStackView()
+        sv.axis = .horizontal
+        return sv
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupViews()
+        setupConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        [
+            weatherIconImageView,
+            popLabel
+        ].forEach { iconAndPopStackView.addArrangedSubview($0) }
+        
+        [
+            lowTempLabel,
+            dailyTemperatureRange,
+            highTempLabel
+        ].forEach { dailyTemperatureRangeStackView.addArrangedSubview($0) }
+        
+        [
+            weekdayLabel,
+            iconAndPopStackView,
+            dailyTemperatureRangeStackView
+        ].forEach { addSubview($0) }
+    }
+    
+    private func setupConstraints() {
+        weekdayLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(24)
+        }
+        
+        weatherIconImageView.snp.makeConstraints {
+            $0.width.height.equalTo(40)
+        }
+        
+        iconAndPopStackView.snp.makeConstraints {
+            $0.leading.equalTo(weekdayLabel.snp.trailing).offset(48)
+        }
+        
+        dailyTemperatureRangeStackView.snp.makeConstraints {
+            $0.leading.equalTo(iconAndPopStackView.snp.trailing).offset(48)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    func configure(with dummyWeather: DummyDailyWeather) {
+        weekdayLabel.text = dummyWeather.date
+        if let url = URL(string: "https://openweathermap.org/img/wn/\(dummyWeather.weatherIcon)@2x.png") {
+            weatherIconImageView.kf.setImage(with: url)
+        }
+        popLabel.text = "\(dummyWeather.pop)"
+        highTempLabel.text = "\(Int(dummyWeather.highTemperature))°C"
+        lowTempLabel.text = "\(Int(dummyWeather.lowTemperature))°C"
+        
+        dailyTemperatureRange.configure(
+            min: dummyWeather.lowTemperature,
+            max: dummyWeather.highTemperature,
+            globalMin: dummyWeather.weeklyLowTemperatures,
+            globalMax: dummyWeather.weeklyHighTemperatures
+        )
+    }
 }

--- a/WeatherApp/WeatherApp/Presentation/Main/View/DailyTemperatureRange.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/DailyTemperatureRange.swift
@@ -9,13 +9,26 @@ import UIKit
 import SnapKit
 
 final class DailyTemperatureRange: UIView {
-    private let barView = UIView()
+    private let backgroundBarView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray5
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    private let barView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBlue
+        view.layer.cornerRadius = 4
+        return view
+    }()
     
     private var minTemp: CGFloat = 0
     private var maxTemp: CGFloat = 0
     private var globalMin: CGFloat = 0
     private var globalMax: CGFloat = 0
     private var isConfigured = false
+    
+    private let gradientLayer = CAGradientLayer()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -29,9 +42,11 @@ final class DailyTemperatureRange: UIView {
     
     private func setupViews() {
         backgroundColor = .clear
-        addSubview(barView)
-        barView.backgroundColor = .systemBlue
-        barView.layer.cornerRadius = 4
+        [
+            backgroundBarView,
+            barView
+        ].forEach { addSubview($0) }
+        barView.layer.addSublayer(gradientLayer)
     }
     
     func configure(min: CGFloat, max: CGFloat, globalMin: CGFloat, globalMax: CGFloat) {
@@ -45,7 +60,6 @@ final class DailyTemperatureRange: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        print("📏 DailyTemperatureRange width:", bounds.width, "height:", bounds.height)
         guard isConfigured else { return }
         guard globalMax > globalMin else { return }
         
@@ -55,12 +69,41 @@ final class DailyTemperatureRange: UIView {
 
         let leftOffset = bounds.width * leftOffsetRatio
         let barWidth = bounds.width * widthRatio
+        
+        backgroundBarView.snp.remakeConstraints {
+            $0.leading.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.height.equalTo(8)
+        }
 
         barView.snp.remakeConstraints {
             $0.leading.equalToSuperview().offset(leftOffset)
             $0.width.equalTo(barWidth)
             $0.centerY.equalToSuperview()
             $0.height.equalTo(8)
+        }
+        
+        gradientLayer.frame = barView.bounds
+        let startColor = color(for: minTemp)
+        let endColor = color(for: maxTemp)
+        gradientLayer.colors = [startColor.cgColor, endColor.cgColor]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        gradientLayer.cornerRadius = 4
+    }
+    
+    func color(for temperature: CGFloat) -> UIColor {
+        switch temperature {
+        case ..<0: return .systemIndigo
+        case 0..<5: return .systemBlue
+        case 5..<10: return .cyan
+        case 10..<15: return .systemTeal
+        case 15..<20: return .systemGreen
+        case 20..<25: return .yellow
+        case 25..<30: return .orange
+        case 30..<35: return .red
+        default: return .brown
         }
     }
 }

--- a/WeatherApp/WeatherApp/Presentation/Main/View/DailyTemperatureRange.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/DailyTemperatureRange.swift
@@ -1,0 +1,43 @@
+//
+//  DailyTemperatureRange.swift
+//  WeatherApp
+//
+//  Created by shinyoungkim on 5/21/25.
+//
+
+import UIKit
+import SnapKit
+
+final class DailyTemperatureRange: UIView {
+    private let barView = UIView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        backgroundColor = .clear
+        addSubview(barView)
+        barView.backgroundColor = .systemBlue
+        barView.layer.cornerRadius = 4
+    }
+    
+    func configure(min: CGFloat, max: CGFloat, globalMin: CGFloat, globalMax: CGFloat) {
+        let totalRange = globalMax - globalMin
+        let leftOffsetRatio = (min - globalMin) / totalRange
+        let widthRatio = (max - min) / totalRange
+        
+        barView.snp.remakeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.height.equalTo(8)
+            $0.leading.equalToSuperview().offset(bounds.width * leftOffsetRatio)
+            $0.width.equalTo(bounds.width * widthRatio)
+        }
+    }
+}

--- a/WeatherApp/WeatherApp/Presentation/Main/View/DailyTemperatureRange.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/DailyTemperatureRange.swift
@@ -11,6 +11,12 @@ import SnapKit
 final class DailyTemperatureRange: UIView {
     private let barView = UIView()
     
+    private var minTemp: CGFloat = 0
+    private var maxTemp: CGFloat = 0
+    private var globalMin: CGFloat = 0
+    private var globalMax: CGFloat = 0
+    private var isConfigured = false
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -29,15 +35,32 @@ final class DailyTemperatureRange: UIView {
     }
     
     func configure(min: CGFloat, max: CGFloat, globalMin: CGFloat, globalMax: CGFloat) {
-        let totalRange = globalMax - globalMin
-        let leftOffsetRatio = (min - globalMin) / totalRange
-        let widthRatio = (max - min) / totalRange
+        self.minTemp = min
+        self.maxTemp = max
+        self.globalMin = globalMin
+        self.globalMax = globalMax
+        self.isConfigured = true
+        setNeedsLayout()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        print("📏 DailyTemperatureRange width:", bounds.width, "height:", bounds.height)
+        guard isConfigured else { return }
+        guard globalMax > globalMin else { return }
         
+        let totalRange = globalMax - globalMin
+        let leftOffsetRatio = (minTemp - globalMin) / totalRange
+        let widthRatio = (maxTemp - minTemp) / totalRange
+
+        let leftOffset = bounds.width * leftOffsetRatio
+        let barWidth = bounds.width * widthRatio
+
         barView.snp.remakeConstraints {
+            $0.leading.equalToSuperview().offset(leftOffset)
+            $0.width.equalTo(barWidth)
             $0.centerY.equalToSuperview()
             $0.height.equalTo(8)
-            $0.leading.equalToSuperview().offset(bounds.width * leftOffsetRatio)
-            $0.width.equalTo(bounds.width * widthRatio)
         }
     }
 }

--- a/WeatherApp/WeatherApp/Presentation/Main/View/DummyMainViewController.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/DummyMainViewController.swift
@@ -14,13 +14,13 @@ class DummyMainViewController: UIViewController {
         case main
     }
     
-    private var dataSource: UICollectionViewDiffableDataSource<Section, DummyHourlyWeather>!
+    private var dataSource: UICollectionViewDiffableDataSource<Section, DummyDailyWeather>!
     
     private lazy var collectionView: UICollectionView = {
-        let cv = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: createDailyLayout())
         cv.register(
-            HourlyWeatherCell.self,
-            forCellWithReuseIdentifier: HourlyWeatherCell.id
+            DailyWeatherCell.self,
+            forCellWithReuseIdentifier: DailyWeatherCell.id
         )
         cv.register(
             SectionHeaderView.self,
@@ -53,7 +53,7 @@ class DummyMainViewController: UIViewController {
         }
     }
     
-    private func createLayout() -> UICollectionViewLayout {
+    private func createHourlyLayout() -> UICollectionViewLayout {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .absolute(60),
             heightDimension: .absolute(60)
@@ -86,9 +86,40 @@ class DummyMainViewController: UIViewController {
         return UICollectionViewCompositionalLayout(section: section)
     }
     
+    private func createDailyLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(50)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(40)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 8
+        section.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+        
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(44)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        section.boundarySupplementaryItems = [header]
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+    
     private func configureDataSource() {
-        dataSource = UICollectionViewDiffableDataSource<Section, DummyHourlyWeather>(collectionView: collectionView) { collectionView, indexPath, item in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HourlyWeatherCell.id, for: indexPath) as? HourlyWeatherCell else {
+        dataSource = UICollectionViewDiffableDataSource<Section, DummyDailyWeather>(collectionView: collectionView) { collectionView, indexPath, item in
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DailyWeatherCell.id, for: indexPath) as? DailyWeatherCell else {
                 return UICollectionViewCell()
             }
             cell.configure(with: item)
@@ -103,29 +134,39 @@ class DummyMainViewController: UIViewController {
                     for: indexPath) as? SectionHeaderView else {
                 return UICollectionReusableView()
             }
-            header.configure(with: "시간대별 날씨")
+            header.configure(with: "요일별 날씨")
             return header
         }
     }
     
     private func applySnapshot() {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, DummyHourlyWeather>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, DummyDailyWeather>()
         snapshot.appendSections([.main])
         snapshot.appendItems(dummyData(), toSection: .main)
         dataSource.apply(snapshot, animatingDifferences: true)
     }
 
-    private func dummyData() -> [DummyHourlyWeather] {
+    private func dummyData() -> [DummyDailyWeather] {
+//        return [
+//            DummyHourlyWeather(time: "10시", weatherIcon: "09n", temperature: "20"),
+//            DummyHourlyWeather(time: "11시", weatherIcon: "09n", temperature: "22"),
+//            DummyHourlyWeather(time: "12시", weatherIcon: "09n", temperature: "19"),
+//            DummyHourlyWeather(time: "13시", weatherIcon: "09n", temperature: "18"),
+//            DummyHourlyWeather(time: "14시", weatherIcon: "09n", temperature: "21"),
+//            DummyHourlyWeather(time: "15시", weatherIcon: "09n", temperature: "23"),
+//            DummyHourlyWeather(time: "16시", weatherIcon: "09n", temperature: "18"),
+//            DummyHourlyWeather(time: "17시", weatherIcon: "09n", temperature: "21"),
+//            DummyHourlyWeather(time: "18시", weatherIcon: "09n", temperature: "23")
+//        ]
         return [
-            DummyHourlyWeather(time: "10시", weatherIcon: "09n", temperature: "20"),
-            DummyHourlyWeather(time: "11시", weatherIcon: "09n", temperature: "22"),
-            DummyHourlyWeather(time: "12시", weatherIcon: "09n", temperature: "19"),
-            DummyHourlyWeather(time: "13시", weatherIcon: "09n", temperature: "18"),
-            DummyHourlyWeather(time: "14시", weatherIcon: "09n", temperature: "21"),
-            DummyHourlyWeather(time: "15시", weatherIcon: "09n", temperature: "23"),
-            DummyHourlyWeather(time: "16시", weatherIcon: "09n", temperature: "18"),
-            DummyHourlyWeather(time: "17시", weatherIcon: "09n", temperature: "21"),
-            DummyHourlyWeather(time: "18시", weatherIcon: "09n", temperature: "23")
+            DummyDailyWeather(date: "오늘", weatherIcon: "09n", pop: "10%", highTemperature: 28, lowTemperature: 16, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "목", weatherIcon: "09n", pop: "20%", highTemperature: 26, lowTemperature: 17, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "금", weatherIcon: "09n", pop: "70%", highTemperature: 23, lowTemperature: 18, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "토", weatherIcon: "09n", pop: "80%", highTemperature: 24, lowTemperature: 19, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "일", weatherIcon: "09n", pop: "30%", highTemperature: 25, lowTemperature: 18, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "월", weatherIcon: "09n", pop: "10%", highTemperature: 27, lowTemperature: 17, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "화", weatherIcon: "09n", pop: "15%", highTemperature: 26, lowTemperature: 18, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16),
+            DummyDailyWeather(date: "수", weatherIcon: "09n", pop: "90%", highTemperature: 22, lowTemperature: 16, weeklyHighTemperatures: 28, weeklyLowTemperatures: 16)
         ]
     }
 }
@@ -134,4 +175,14 @@ struct DummyHourlyWeather: Hashable {
     let time: String
     let weatherIcon: String
     let temperature: String
+}
+
+struct DummyDailyWeather: Hashable {
+    let date: String
+    let weatherIcon: String
+    let pop: String
+    let highTemperature: CGFloat
+    let lowTemperature: CGFloat
+    let weeklyHighTemperatures: CGFloat
+    let weeklyLowTemperatures: CGFloat
 }


### PR DESCRIPTION
closed: #13 

변경사항
- 일교차를 막대 형태로 시각화했습니다.
- 8일간 최저, 최고 기온, 일별 최저, 최고 기온 총 4개의 값이 사용됩니다.
- 백그라운드 회색 바는 8일간 최저기온부터 최고기온까지 전체 범위를 나타냅니다.
- 그라디언트 바는 일별 최저기온부터 최고기온까지 일교차 범위를 나타냅니다.
- 기온을 구간 단위로 나눠서 색을 미리 지정하고 최저 기온에 해당하는 색 -> 최고 기온에 해당하는 색으로 그라디언트를 설정하는 방법입니다.
- 예를 들어, 최저 18도, 최고 26일 경우 18도는 15 ~ 20 구간에 해당하여 green, 26도는 25 ~ 30 구간에 해당하여 orange입니다.

참고사항
- 데이터 주입 방법은 나중에 실제 데이터에 적용될때 제대로 변경될 예정입니다.
- 구현에 초점을 맞췄으며 추후 디테일한 레이아웃 설정들은 조금씩 변경하겠습니다.

기본 색이라 뭔가 어색하네요 고급진 색상 추천 부탁드립니다 🙈

스크린샷
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2108779d-c3ce-46e6-8de9-1ed1d12043bb" />
