### PR TITLE
feat: 메인 뷰 내 컬렉션뷰 다중 섹션 기초 레이아웃 적용

### DIFF
--- a/WeatherApp/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp/WeatherApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		95622AAF2DDF37A1002FE94C /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = 95622AAE2DDF37A1002FE94C /* Differentiator */; };
+		95622AB12DDF37A1002FE94C /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = 95622AB02DDF37A1002FE94C /* RxDataSources */; };
 		E8AF753D2DDC9310009A1DA0 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = E8AF753C2DDC9310009A1DA0 /* Kingfisher */; };
 		E8AF75402DDC937C009A1DA0 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = E8AF753F2DDC937C009A1DA0 /* RxCocoa */; };
 		E8AF75422DDC937C009A1DA0 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = E8AF75412DDC937C009A1DA0 /* RxRelay */; };
@@ -77,6 +79,8 @@
 				E8AF75402DDC937C009A1DA0 /* RxCocoa in Frameworks */,
 				E8AF75442DDC937C009A1DA0 /* RxSwift in Frameworks */,
 				E8AF753D2DDC9310009A1DA0 /* Kingfisher in Frameworks */,
+				95622AB12DDF37A1002FE94C /* RxDataSources in Frameworks */,
+				95622AAF2DDF37A1002FE94C /* Differentiator in Frameworks */,
 				E8AF75472DDC9390009A1DA0 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -143,6 +147,8 @@
 				E8AF75412DDC937C009A1DA0 /* RxRelay */,
 				E8AF75432DDC937C009A1DA0 /* RxSwift */,
 				E8AF75462DDC9390009A1DA0 /* SnapKit */,
+				95622AAE2DDF37A1002FE94C /* Differentiator */,
+				95622AB02DDF37A1002FE94C /* RxDataSources */,
 			);
 			productName = WeatherApp;
 			productReference = E8AF74F82DDC8DD6009A1DA0 /* WeatherApp.app */;
@@ -230,6 +236,7 @@
 				E8AF753B2DDC9310009A1DA0 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				E8AF753E2DDC937C009A1DA0 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				E8AF75452DDC9390009A1DA0 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				95622AAD2DDF37A1002FE94C /* XCRemoteSwiftPackageReference "RxDataSources" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E8AF74F92DDC8DD6009A1DA0 /* Products */;
@@ -312,7 +319,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 52YSN62MCL;
+				DEVELOPMENT_TEAM = R6V7ZUXR5H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WeatherApp/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -344,7 +351,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 52YSN62MCL;
+				DEVELOPMENT_TEAM = R6V7ZUXR5H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WeatherApp/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -606,6 +613,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		95622AAD2DDF37A1002FE94C /* XCRemoteSwiftPackageReference "RxDataSources" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RxSwiftCommunity/RxDataSources.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.2;
+			};
+		};
 		E8AF753B2DDC9310009A1DA0 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
@@ -633,6 +648,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		95622AAE2DDF37A1002FE94C /* Differentiator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 95622AAD2DDF37A1002FE94C /* XCRemoteSwiftPackageReference "RxDataSources" */;
+			productName = Differentiator;
+		};
+		95622AB02DDF37A1002FE94C /* RxDataSources */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 95622AAD2DDF37A1002FE94C /* XCRemoteSwiftPackageReference "RxDataSources" */;
+			productName = RxDataSources;
+		};
 		E8AF753C2DDC9310009A1DA0 /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E8AF753B2DDC9310009A1DA0 /* XCRemoteSwiftPackageReference "Kingfisher" */;

--- a/WeatherApp/WeatherApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WeatherApp/WeatherApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1d0a1d1ef24174923b48544be4aa739e1947399a5ae10b23512c9ede288ec368",
+  "originHash" : "e522ecd235d1bb81f1f1b880c2330851c5b18798a4e77d0effc56e8afd413c94",
   "pins" : [
     {
       "identity" : "kingfisher",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "7deda23bbdca612076c5c315003d8638a08ed0f1",
         "version" : "8.3.2"
+      }
+    },
+    {
+      "identity" : "rxdatasources",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxDataSources.git",
+      "state" : {
+        "revision" : "90c29b48b628479097fe775ed1966d75ac374518",
+        "version" : "5.0.2"
       }
     },
     {

--- a/WeatherApp/WeatherApp/App/SceneDelegate.swift
+++ b/WeatherApp/WeatherApp/App/SceneDelegate.swift
@@ -19,15 +19,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = scene as? UIWindowScene else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        
+
+        let mainViewModel = MainViewModel(
+            fetchDailyWeatherUseCase: FetchDailyWeatherUseCase(repository: WeatherRepositoryImpl()),
+            fetchHourlyWeatherUseCase: FetchHourlyWeatherUseCase(repository: WeatherRepositoryImpl()),
+            fetchCurrentWeatherUseCase: FetchCurrentWeatherUseCase(repository: WeatherRepositoryImpl()),
+            getCurrentLocationUseCase: GetCurrentLocationUseCase(repository: LocationRepository(locationService: LocationService())), reverseGeocodingUseCase: ReverseGeocodingUseCase(repository: ReverseGeocodingRepository(reverseGeocodingService: ReverseGeocodingService()))
+        )
+        let mainDetailViewModel = MainDetailViewModel(
+            hourlyWeatherObservable: mainViewModel.hourlyWeather,
+            dailyWeatherObservable: mainViewModel.dailyWeather
+        )
+
         let rootViewController = MainPageViewController(
             viewModel: PageViewModel(),
-            mainViewModel: MainViewModel(
-                fetchDailyWeatherUseCase: FetchDailyWeatherUseCase(repository: WeatherRepositoryImpl()),
-                fetchHourlyWeatherUseCase: FetchHourlyWeatherUseCase(repository: WeatherRepositoryImpl()),
-                fetchCurrentWeatherUseCase: FetchCurrentWeatherUseCase(repository: WeatherRepositoryImpl()),
-                getCurrentLocationUseCase: GetCurrentLocationUseCase(repository: LocationRepository(locationService: LocationService())), reverseGeocodingUseCase: ReverseGeocodingUseCase(repository: ReverseGeocodingRepository(reverseGeocodingService: ReverseGeocodingService()))
-            )
+            mainViewModel: mainViewModel,
+            mainDetailViewModel: mainDetailViewModel
         )
         window.rootViewController = UINavigationController(rootViewController: rootViewController)
         

--- a/WeatherApp/WeatherApp/Common/Extensions/UICollectionView+.swift
+++ b/WeatherApp/WeatherApp/Common/Extensions/UICollectionView+.swift
@@ -1,0 +1,20 @@
+//
+//  UICollectionView+.swift
+//  WeatherApp
+//
+//  Created by 송규섭 on 5/23/25.
+//
+
+import UIKit
+
+extension UICollectionView {
+    static func withCompositionalLayout() -> UICollectionView {
+        let layout = UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) in
+            if let section = Section(sectionIndex) {
+                return section.layoutSection
+            }
+            return nil
+        }
+        return UICollectionView(frame: .zero, collectionViewLayout: layout)
+    }
+}

--- a/WeatherApp/WeatherApp/Presentation/Main/View/MainPageViewController.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/MainPageViewController.swift
@@ -12,17 +12,20 @@ class MainPageViewController: UIPageViewController {
     private let disposeBag = DisposeBag()
     private let viewModel: PageViewModel
     private let mainViewModel: MainViewModel
+    private let mainDetailViewModel: MainDetailViewModel
 
     private lazy var mainVC = MainViewController(viewModel: self.mainViewModel)
-    private lazy var mainDetailVC = MainDetailViewController(viewModel: self.mainViewModel)
+    private lazy var mainDetailVC = MainDetailViewController(viewModel: self.mainDetailViewModel)
     private lazy var pages: [UIViewController] = [
         mainVC, mainDetailVC
     ]
 
     init(viewModel: PageViewModel,
-         mainViewModel: MainViewModel) {
+         mainViewModel: MainViewModel,
+         mainDetailViewModel: MainDetailViewModel) {
         self.viewModel = viewModel
         self.mainViewModel = mainViewModel
+        self.mainDetailViewModel = mainDetailViewModel
         super.init(transitionStyle: .scroll, navigationOrientation: .vertical, options: nil)
         dataSource = self
         delegate = self

--- a/WeatherApp/WeatherApp/Presentation/Main/View/MainViewController.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/MainViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 import SnapKit
+import RxDataSources
 
 class MainViewController: UIViewController {
     private let viewModel: MainViewModel
@@ -208,5 +209,6 @@ private extension MainViewController {
         viewModel.currentLocationText?
             .drive(locationWeatherLabel.rx.text)
             .disposed(by: disposeBag)
+        
     }
 }

--- a/WeatherApp/WeatherApp/Presentation/Main/View/Section.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/Section.swift
@@ -1,0 +1,104 @@
+//
+//  Section.swift
+//  WeatherApp
+//
+//  Created by 송규섭 on 5/23/25.
+//
+
+import UIKit
+
+enum Section {
+    case daily
+    case hourly
+
+    init?(_ sectionNumber: Int) {
+        switch sectionNumber {
+        case 0:
+            self = .hourly
+        case 1:
+            self = .daily
+        default:
+            return nil
+        }
+    }
+
+    var sectionNumber: Int {
+        switch self {
+        case .hourly:
+            return 0
+        case .daily:
+            return 1
+        }
+    }
+
+    var layoutSection: NSCollectionLayoutSection {
+        switch self {
+        case .hourly: return Self.createHourlyLayout()
+        case .daily: return Self.createDailyLayout()
+        }
+    }
+
+    static func createHourlyLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(60),
+            heightDimension: .absolute(60)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .estimated(60 * 5),
+            heightDimension: .absolute(60)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 8
+        section.contentInsets = .init(top: 12, leading: 8, bottom: 28, trailing: 8)
+
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(44)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+
+        section.boundarySupplementaryItems = [header]
+
+        return section
+    }
+
+    static func createDailyLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(50)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(40)
+        )
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 8
+        section.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(44)
+        )
+        let header = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+        section.boundarySupplementaryItems = [header]
+
+        return section
+    }
+}

--- a/WeatherApp/WeatherApp/Presentation/Main/View/Section/MainSectionModel.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/Section/MainSectionModel.swift
@@ -1,0 +1,32 @@
+//
+//  MainSectionModel.swift
+//  WeatherApp
+//
+//  Created by 송규섭 on 5/22/25.
+//
+
+import Foundation
+import RxDataSources
+
+enum MainSectionModel {
+    case daily(items: [SectionItem])
+    case hourly(items: [SectionItem])
+}
+
+extension MainSectionModel: SectionModelType {
+    var items: [SectionItem] {
+        switch self {
+        case .daily(let items): return items
+        case .hourly(let items): return items
+        }
+    }
+    
+    init(original: MainSectionModel, items: [SectionItem]) {
+        switch original {
+        case .daily: self = .daily(items: items)
+        case .hourly: self = .hourly(items: items)
+        }
+    }
+    
+    typealias Item = SectionItem
+}

--- a/WeatherApp/WeatherApp/Presentation/Main/View/Section/SectionItem.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/View/Section/SectionItem.swift
@@ -1,0 +1,13 @@
+//
+//  SectionItem.swift
+//  WeatherApp
+//
+//  Created by 송규섭 on 5/22/25.
+//
+
+import Foundation
+
+enum SectionItem {
+    case dailyWeatherItem(DailyWeather)
+    case hourlyWeatherItem(HourlyWeather)
+}

--- a/WeatherApp/WeatherApp/Presentation/Main/ViewModel/MainDetailViewModel.swift
+++ b/WeatherApp/WeatherApp/Presentation/Main/ViewModel/MainDetailViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  MainDetailViewModel.swift
+//  WeatherApp
+//
+//  Created by 송규섭 on 5/22/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+final class MainDetailViewModel {
+
+    var sections: Observable<[MainSectionModel]>?
+    private let hourlyWeatherObservable: Observable<[HourlyWeather]>
+    private let dailyWeatherObservable: Observable<[DailyWeather]>
+
+    init(hourlyWeatherObservable: Observable<[HourlyWeather]>, dailyWeatherObservable: Observable<[DailyWeather]>) {
+        self.hourlyWeatherObservable = hourlyWeatherObservable
+        self.dailyWeatherObservable = dailyWeatherObservable
+
+        bind()
+    }
+
+    func bind() {
+        sections = Observable.combineLatest(hourlyWeatherObservable, dailyWeatherObservable)
+            .map({ hourly, daily in
+                return [
+                    .hourly(items: hourly.map { .hourlyWeatherItem($0) }),
+                    .daily(items: daily.map { .dailyWeatherItem($0) })
+                ]
+            })
+    }
+}


### PR DESCRIPTION
## 🔧 관련 이슈
#5 

## ✨ 변경 사항 및 이유
- RxDataSources에 맞춰 2개의 섹션 구현
- 섹션 별 layout을 enum을 통해 접근할 수 있도록 구현
- collectionView extension을 통해 타입 메서드 구현

## 🔍 PR Point
- 없음

## 📌 참고 사항
데이터 바인딩에 대해선 좀 더 맞춰봐야 할 것 같습니다.
뷰모델의 경우 두 가지가 되는데 viewWillAppear에 트리거가 되면서 하나의 뷰모델에서만 작동되는 관계로 다룰 데이터를 모두 mainViewModel에서 관리하고 이중 필요한 데이터를 DI 시 mainDetailViewModel로 전달하는 방식으로 구현했습니다.